### PR TITLE
aik_manager: Add prop.default to buildprop_locations

### DIFF
--- a/twrpdtgen/utils/aik_manager.py
+++ b/twrpdtgen/utils/aik_manager.py
@@ -107,6 +107,7 @@ class AIKManager:
 		# Get a usable build.prop to parse
 		self.buildprop = None
 		buildprop_locations = [self.ramdisk_path / "default.prop",
+							   self.ramdisk_path / "prop.default",
 							   self.ramdisk_path / "vendor" / "build.prop",
 							   self.ramdisk_path / "system" / "build.prop",
 							   self.ramdisk_path / "system" / "etc" / "build.prop"]


### PR DESCRIPTION
Fixes: https://github.com/SebaUbuntu/TWRP-device-tree-generator/issues/77
Signed-off-by: trkzmn <trkzmn89@gmail.com>