### PR TITLE
twrpdtgen: Fix parsing of DEVICE_ARCH

### DIFF
--- a/twrpdtgen/utils/deviceinfo.py
+++ b/twrpdtgen/utils/deviceinfo.py
@@ -9,16 +9,16 @@ from twrpdtgen.utils.buildprop import BuildProp
 
 PARTITIONS = [
 	"",
-	"bootimage.",
-	"odm.",
-	"product.",
-	"system.",
-	"system_ext.",
-	"vendor.",
+	"bootimage",
+	"odm",
+	"product",
+	"system",
+	"system_ext",
+	"vendor",
 ]
 
 def get_product_props(value: str):
-	return [f"ro.product.{partition}{value}" for partition in PARTITIONS]
+	return [f"ro.product.{partition}.{value}" for partition in PARTITIONS]
 
 DEVICE_CODENAME = get_product_props("device")
 DEVICE_MANUFACTURER = get_product_props("manufacturer")


### PR DESCRIPTION
- Rework the parsing logic to remove the extra "." separator that gets added after the partition name.

Fixes #85 

There was no separator in Line 22 of utils/deviceinfo.py
```
return [f"ro.product.{partition}{value}" for partition in PARTITIONS]
``` 
as separators were added in the partition list itself in line 10 but in line 27
```
DEVICE_ARCH = ["ro.product.cpu.abi", "ro.product.cpu.abilist"] + [f"ro.{partition}.product.cpu.abi" for partition in PARTITIONS] + [f"ro.{partition}.product.cpu.abilist" for partition in PARTITIONS]
```
separators were added in between the partition name and rest of the prop and when parsing the props an extra separator was being added which was present in the partitions list. This commit removes the separators in the partition list and adds a separator in line 22 thus fixing the issue.

Thanks.